### PR TITLE
Update Ratio.php to add compatibility with Tailwind Embeds

### DIFF
--- a/src/ValueObjects/Ratio.php
+++ b/src/ValueObjects/Ratio.php
@@ -20,6 +20,11 @@ class Ratio
 
         return (float) round($percentage, 2);
     }
+    
+    public function withSlash()
+    {
+        return $this->width . '/' . $this->height;
+    }
 
     protected function parseRatioString(string $ratio): array
     {


### PR DESCRIPTION
Added the Slash option for using with Tailwind Responsive Embeds
https://github.com/drdogbot7/tailwindcss-responsive-embed

responsive-wrapper actually has this code

```
<div 
    class="laravel-embed__responsive-wrapper" 
    style="padding-bottom: {{ $aspectRatio->asPercentage() }}%"
>
    {{ $slot }}
</div>
```

It should be like this to use with Tailwind

```
<div class="embed-responsive aspect-ratio-{{ $aspectRatio->withSlash() }} w-full">
    {{ $slot }}
</div>
```